### PR TITLE
Updated all topics with IoT4I SaaS availability & link to related doc.

### DIFF
--- a/iotinsurance_data_backup.md
+++ b/iotinsurance_data_backup.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2016, 2017
-lastupdated: "2017-12-01"
+lastupdated: "2017-12-28"
 ---
 
 <!-- Common attributes used in the template are defined as follows: -->
@@ -19,8 +19,14 @@ lastupdated: "2017-12-01"
 # Backing up data (Deprecated)
 {: #backing_up_data}
 
-**This service is deprecated:** Existing instances of this service can be used until 12 December 2018. For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.  
-{:deprecated}
+**This service is deprecated:** For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.
+
+However, {{site.data.keyword.iotinsurance_short}} is not going away. As of 31 July 2017, {{site.data.keyword.iotinsurance_short}} became a SaaS offering. The SaaS offering is available on [IBM Marketplace](https://www.ibm.com/us-en/marketplace/ibm-iot-for-insurance){: new_window}. Product documentation for the {{site.data.keyword.iotinsurance_full}} SaaS offering is in the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSQNYQ/iot-insurance/kc_welcome.html){: new_window}.
+
+Existing instances of this service can be used until 12 December 2018. However, you are encouraged to migrate to the {{site.data.keyword.iotinsurance_short}} SaaS offering. If you have data from this service that you want to migrate to the SaaS offering, you must open a [ticket at https://console.bluemix.net/](https://console.bluemix.net/){: new_window} under **Support > Add Ticket**.  
+{: deprecated}
+
+---
 
 
 You can back up your {{site.data.keyword.iotinsurance_full}} data by replicating the {{site.data.keyword.cloudantfull}} database.

--- a/iotinsurance_device_toolkit.md
+++ b/iotinsurance_device_toolkit.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2016, 2017
-lastupdated: "2017-12-01"
+lastupdated: "2017-12-28"
 ---
 
 <!-- Common attributes used in the template are defined as follows: -->
@@ -17,8 +17,14 @@ lastupdated: "2017-12-01"
 # Using the device toolkit (Deprecated)
 {: #iot4i_connecting_devices}
 
-**This service is deprecated:** Existing instances of this service can be used until 12 December 2018. For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.  
-{:deprecated}
+**This service is deprecated:** For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.
+
+However, {{site.data.keyword.iotinsurance_short}} is not going away. As of 31 July 2017, {{site.data.keyword.iotinsurance_short}} became a SaaS offering. The SaaS offering is available on [IBM Marketplace](https://www.ibm.com/us-en/marketplace/ibm-iot-for-insurance){: new_window}. Product documentation for the {{site.data.keyword.iotinsurance_full}} SaaS offering is in the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSQNYQ/iot-insurance/kc_welcome.html){: new_window}.
+
+Existing instances of this service can be used until 12 December 2018. However, you are encouraged to migrate to the {{site.data.keyword.iotinsurance_short}} SaaS offering. If you have data from this service that you want to migrate to the SaaS offering, you must open a [ticket at https://console.bluemix.net/](https://console.bluemix.net/){: new_window} under **Support > Add Ticket**.  
+{: deprecated}
+
+---
 
 By using the {{site.data.keyword.iotinsurance_full}} Device Toolkit, you can connect devices that are made by any device vendor to your {{site.data.keyword.iotinsurance_short}} service.
 {:shortdesc}

--- a/iotinsurance_extending_service.md
+++ b/iotinsurance_extending_service.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2016, 2017
-lastupdated: "2017-12-01"
+lastupdated: "2017-12-28"
 ---
 
 <!-- Common attributes used in the template are defined as follows: -->
@@ -17,8 +17,14 @@ lastupdated: "2017-12-01"
 # Extending the service with APIs (Deprecated)
 {: #iot4i_extending_service}
 
-**This service is deprecated:** Existing instances of this service can be used until 12 December 2018. For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.  
-{:deprecated}
+**This service is deprecated:** For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.
+
+However, {{site.data.keyword.iotinsurance_short}} is not going away. As of 31 July 2017, {{site.data.keyword.iotinsurance_short}} became a SaaS offering. The SaaS offering is available on [IBM Marketplace](https://www.ibm.com/us-en/marketplace/ibm-iot-for-insurance){: new_window}. Product documentation for the {{site.data.keyword.iotinsurance_full}} SaaS offering is in the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSQNYQ/iot-insurance/kc_welcome.html){: new_window}.
+
+Existing instances of this service can be used until 12 December 2018. However, you are encouraged to migrate to the {{site.data.keyword.iotinsurance_short}} SaaS offering. If you have data from this service that you want to migrate to the SaaS offering, you must open a [ticket at https://console.bluemix.net/](https://console.bluemix.net/){: new_window} under **Support > Add Ticket**.  
+{: deprecated}
+
+---
 
 {{site.data.keyword.iotinsurance_full}} provides APIs to customize and extend your {{site.data.keyword.iotinsurance_short}} solution.
 {:shortdesc}

--- a/iotinsurance_how_service_works.md
+++ b/iotinsurance_how_service_works.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2016, 2017
-lastupdated: "2017-12-01"
+lastupdated: "2017-12-28"
 ---
 
 <!-- Common attributes used in the template are defined as follows: -->
@@ -16,8 +16,14 @@ lastupdated: "2017-12-01"
 # How the service works (Deprecated)
 {: #iot4i_how_service_works}
 
-**This service is deprecated:** Existing instances of this service can be used until 12 December 2018. For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.  
-{:deprecated}
+**This service is deprecated:** For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.
+
+However, {{site.data.keyword.iotinsurance_short}} is not going away. As of 31 July 2017, {{site.data.keyword.iotinsurance_short}} became a SaaS offering. The SaaS offering is available on [IBM Marketplace](https://www.ibm.com/us-en/marketplace/ibm-iot-for-insurance){: new_window}. Product documentation for the {{site.data.keyword.iotinsurance_full}} SaaS offering is in the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSQNYQ/iot-insurance/kc_welcome.html){: new_window}.
+
+Existing instances of this service can be used until 12 December 2018. However, you are encouraged to migrate to the {{site.data.keyword.iotinsurance_short}} SaaS offering. If you have data from this service that you want to migrate to the SaaS offering, you must open a [ticket at https://console.bluemix.net/](https://console.bluemix.net/){: new_window} under **Support > Add Ticket**.  
+{: deprecated}
+
+---
 
 
 {{site.data.keyword.iotinsurance_full}} creates a flow to collect, manage, and analyze data from connected policy holders.

--- a/iotinsurance_mobile_app.md
+++ b/iotinsurance_mobile_app.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2016, 2017
-lastupdated: "2017-12-01"
+lastupdated: "2017-12-28"
 ---
 
 <!-- Common attributes used in the template are defined as follows: -->
@@ -20,8 +20,14 @@ lastupdated: "2017-12-01"
 # Installing and connecting the sample mobile app (Deprecated)
 {: #iot4i_gettingstarted}
 
-**This service is deprecated:** Existing instances of this service can be used until 12 December 2018. For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.  
-{:deprecated}
+**This service is deprecated:** For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.
+
+However, {{site.data.keyword.iotinsurance_short}} is not going away. As of 31 July 2017, {{site.data.keyword.iotinsurance_short}} became a SaaS offering. The SaaS offering is available on [IBM Marketplace](https://www.ibm.com/us-en/marketplace/ibm-iot-for-insurance){: new_window}. Product documentation for the {{site.data.keyword.iotinsurance_full}} SaaS offering is in the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSQNYQ/iot-insurance/kc_welcome.html){: new_window}.
+
+Existing instances of this service can be used until 12 December 2018. However, you are encouraged to migrate to the {{site.data.keyword.iotinsurance_short}} SaaS offering. If you have data from this service that you want to migrate to the SaaS offering, you must open a [ticket at https://console.bluemix.net/](https://console.bluemix.net/){: new_window} under **Support > Add Ticket**.  
+{: deprecated}
+
+---
 
 
 The {{site.data.keyword.iotinsurance_full}} sample mobile app is a reference implementation for a mobile client of {{site.data.keyword.iotinsurance_short}}. You can use the app to register new devices in the system and receive alerts for the devices.

--- a/iotinsurance_optimizing_performance.md
+++ b/iotinsurance_optimizing_performance.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2016, 2017
-lastupdated: "2017-12-01"
+lastupdated: "2017-12-28"
 ---
 
 <!-- Common attributes used in the template are defined as follows: -->
@@ -21,8 +21,14 @@ lastupdated: "2017-12-01"
 # Optimizing performance with advanced services (Deprecated)
 {: #iotins_advancedservices}
 
-**This service is deprecated:** Existing instances of this service can be used until 12 December 2018. For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.  
-{:deprecated}
+**This service is deprecated:** For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.
+
+However, {{site.data.keyword.iotinsurance_short}} is not going away. As of 31 July 2017, {{site.data.keyword.iotinsurance_short}} became a SaaS offering. The SaaS offering is available on [IBM Marketplace](https://www.ibm.com/us-en/marketplace/ibm-iot-for-insurance){: new_window}. Product documentation for the {{site.data.keyword.iotinsurance_full}} SaaS offering is in the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSQNYQ/iot-insurance/kc_welcome.html){: new_window}.
+
+Existing instances of this service can be used until 12 December 2018. However, you are encouraged to migrate to the {{site.data.keyword.iotinsurance_short}} SaaS offering. If you have data from this service that you want to migrate to the SaaS offering, you must open a [ticket at https://console.bluemix.net/](https://console.bluemix.net/){: new_window} under **Support > Add Ticket**.  
+{: deprecated}
+
+---
 
 To optimize performance and monitor your {{site.data.keyword.iotinsurance_short}} instance, you can create and configure one or more advanced services in {{site.data.keyword.Bluemix_notm}}.
 {:shortdesc}

--- a/iotinsurance_overview.md
+++ b/iotinsurance_overview.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2016, 2017
-lastupdated: "2017-12-01"
+lastupdated: "2017-12-28"
 ---
 
 <!-- Common attributes used in the template are defined as follows: -->
@@ -17,8 +17,14 @@ lastupdated: "2017-12-01"
 # About {{site.data.keyword.iotinsurance_short}} (Deprecated)
 {: #about}
 
-**This service is deprecated:** Existing instances of this service can be used until 12 December 2018. For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.  
-{:deprecated}
+**This service is deprecated:** For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.
+
+However, {{site.data.keyword.iotinsurance_short}} is not going away. As of 31 July 2017, {{site.data.keyword.iotinsurance_short}} became a SaaS offering. The SaaS offering is available on [IBM Marketplace](https://www.ibm.com/us-en/marketplace/ibm-iot-for-insurance){: new_window}. Product documentation for the {{site.data.keyword.iotinsurance_full}} SaaS offering is in the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSQNYQ/iot-insurance/kc_welcome.html){: new_window}.
+
+Existing instances of this service can be used until 12 December 2018. However, you are encouraged to migrate to the {{site.data.keyword.iotinsurance_short}} SaaS offering. If you have data from this service that you want to migrate to the SaaS offering, you must open a [ticket at https://console.bluemix.net/](https://console.bluemix.net/){: new_window} under **Support > Add Ticket**.  
+{: deprecated}
+
+---
 
 {{site.data.keyword.iotinsurance_full}} is an integrated IoT production instance that collects and analyzes full-context data from policy holders to provide personalized risk assessments, real-time protection, and policy cost reductions.
 {: shortdesc}

--- a/iotinsurance_shield_toolkit.md
+++ b/iotinsurance_shield_toolkit.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2016, 2017
-lastupdated: "2017-12-01"
+lastupdated: "2017-12-28"
 ---
 
 <!-- Common attributes used in the template are defined as follows: -->
@@ -17,8 +17,14 @@ lastupdated: "2017-12-01"
 # Using the shield toolkit (Deprecated)
 {: #iot4i_shield_toolkit}
 
-**This service is deprecated:** Existing instances of this service can be used until 12 December 2018. For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.  
-{:deprecated}
+**This service is deprecated:** For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.
+
+However, {{site.data.keyword.iotinsurance_short}} is not going away. As of 31 July 2017, {{site.data.keyword.iotinsurance_short}} became a SaaS offering. The SaaS offering is available on [IBM Marketplace](https://www.ibm.com/us-en/marketplace/ibm-iot-for-insurance){: new_window}. Product documentation for the {{site.data.keyword.iotinsurance_full}} SaaS offering is in the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSQNYQ/iot-insurance/kc_welcome.html){: new_window}.
+
+Existing instances of this service can be used until 12 December 2018. However, you are encouraged to migrate to the {{site.data.keyword.iotinsurance_short}} SaaS offering. If you have data from this service that you want to migrate to the SaaS offering, you must open a [ticket at https://console.bluemix.net/](https://console.bluemix.net/){: new_window} under **Support > Add Ticket**.  
+{: deprecated}
+
+---
 
 Use shields to protect property and users by identifying hazards and creating appropriate automated responses. Use or modify the shields that are included in the {{site.data.keyword.iotinsurance_short}} shields library or create and implement your own shields by using the instructions and examples that follow.
 {:shortdesc}

--- a/iotinsurance_sms_voice_integration.md
+++ b/iotinsurance_sms_voice_integration.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2016, 2017
-lastupdated: "2017-12-01"
+lastupdated: "2017-12-28"
 ---
 
 <!-- Common attributes used in the template are defined as follows: -->
@@ -18,8 +18,14 @@ lastupdated: "2017-12-01"
 # Enabling SMS and voice messaging (Deprecated)
 {: #supportedcloud}
 
-**This service is deprecated:** Existing instances of this service can be used until 12 December 2018. For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.  
-{:deprecated}
+**This service is deprecated:** For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.
+
+However, {{site.data.keyword.iotinsurance_short}} is not going away. As of 31 July 2017, {{site.data.keyword.iotinsurance_short}} became a SaaS offering. The SaaS offering is available on [IBM Marketplace](https://www.ibm.com/us-en/marketplace/ibm-iot-for-insurance){: new_window}. Product documentation for the {{site.data.keyword.iotinsurance_full}} SaaS offering is in the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSQNYQ/iot-insurance/kc_welcome.html){: new_window}.
+
+Existing instances of this service can be used until 12 December 2018. However, you are encouraged to migrate to the {{site.data.keyword.iotinsurance_short}} SaaS offering. If you have data from this service that you want to migrate to the SaaS offering, you must open a [ticket at https://console.bluemix.net/](https://console.bluemix.net/){: new_window} under **Support > Add Ticket**.  
+{: deprecated}
+
+---
 
 
 {{site.data.keyword.iotinsurance_full}} supports integration with Twilio to enable SMS and voice messaging. Twilio is a third-party application, which you can install in your {{site.data.keyword.Bluemix_notm}} dashboard.

--- a/iotinsurance_supporteddevices.md
+++ b/iotinsurance_supporteddevices.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2016, 2017
-lastupdated: "2017-12-01"
+lastupdated: "2017-12-28"
 ---
 
 <!-- Common attributes used in the template are defined as follows: -->
@@ -17,8 +17,14 @@ lastupdated: "2017-12-01"
 # Supported devices and vendors (Deprecated)
 {: #supported_devices}
 
-**This service is deprecated:** Existing instances of this service can be used until 12 December 2018. For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.  
-{:deprecated}
+**This service is deprecated:** For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.
+
+However, {{site.data.keyword.iotinsurance_short}} is not going away. As of 31 July 2017, {{site.data.keyword.iotinsurance_short}} became a SaaS offering. The SaaS offering is available on [IBM Marketplace](https://www.ibm.com/us-en/marketplace/ibm-iot-for-insurance){: new_window}. Product documentation for the {{site.data.keyword.iotinsurance_full}} SaaS offering is in the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSQNYQ/iot-insurance/kc_welcome.html){: new_window}.
+
+Existing instances of this service can be used until 12 December 2018. However, you are encouraged to migrate to the {{site.data.keyword.iotinsurance_short}} SaaS offering. If you have data from this service that you want to migrate to the SaaS offering, you must open a [ticket at https://console.bluemix.net/](https://console.bluemix.net/){: new_window} under **Support > Add Ticket**.  
+{: deprecated}
+
+---
 
 {{site.data.keyword.iotinsurance_full}} supports integration with multiple cloud vendors and devices.
 {: shortdesc}

--- a/iotinsurance_troubleshooting.md
+++ b/iotinsurance_troubleshooting.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2016, 2017
-lastupdated: "2017-12-01"
+lastupdated: "2017-12-28"
 ---
 
 <!-- Common attributes used in the template are defined as follows: -->
@@ -17,8 +17,14 @@ lastupdated: "2017-12-01"
 # {{site.data.keyword.iotinsurance_short}} troubleshooting (Deprecated)
 {: #ts}
 
-**This service is deprecated:** Existing instances of this service can be used until 12 December 2018. For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.  
-{:deprecated}
+**This service is deprecated:** For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.
+
+However, {{site.data.keyword.iotinsurance_short}} is not going away. As of 31 July 2017, {{site.data.keyword.iotinsurance_short}} became a SaaS offering. The SaaS offering is available on [IBM Marketplace](https://www.ibm.com/us-en/marketplace/ibm-iot-for-insurance){: new_window}. Product documentation for the {{site.data.keyword.iotinsurance_full}} SaaS offering is in the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSQNYQ/iot-insurance/kc_welcome.html){: new_window}.
+
+Existing instances of this service can be used until 12 December 2018. However, you are encouraged to migrate to the {{site.data.keyword.iotinsurance_short}} SaaS offering. If you have data from this service that you want to migrate to the SaaS offering, you must open a [ticket at https://console.bluemix.net/](https://console.bluemix.net/){: new_window} under **Support > Add Ticket**.  
+{: deprecated}
+
+---
 
 Here are the answers to common troubleshooting questions about using {{site.data.keyword.iotinsurance_full}} on {{site.data.keyword.Bluemix_notm}}.
 {:shortdesc}

--- a/iotinsurance_upgrading.md
+++ b/iotinsurance_upgrading.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2016, 2017
-lastupdated: "2017-12-01"
+lastupdated: "2017-12-28"
 ---
 
 <!-- Common attributes used in the template are defined as follows: -->
@@ -21,8 +21,14 @@ lastupdated: "2017-12-01"
 # Upgrading to a new version (Deprecated)
 {: #upgrading}
 
-**This service is deprecated:** Existing instances of this service can be used until 12 December 2018. For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.  
-{:deprecated}
+**This service is deprecated:** For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.
+
+However, {{site.data.keyword.iotinsurance_short}} is not going away. As of 31 July 2017, {{site.data.keyword.iotinsurance_short}} became a SaaS offering. The SaaS offering is available on [IBM Marketplace](https://www.ibm.com/us-en/marketplace/ibm-iot-for-insurance){: new_window}. Product documentation for the {{site.data.keyword.iotinsurance_full}} SaaS offering is in the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSQNYQ/iot-insurance/kc_welcome.html){: new_window}.
+
+Existing instances of this service can be used until 12 December 2018. However, you are encouraged to migrate to the {{site.data.keyword.iotinsurance_short}} SaaS offering. If you have data from this service that you want to migrate to the SaaS offering, you must open a [ticket at https://console.bluemix.net/](https://console.bluemix.net/){: new_window} under **Support > Add Ticket**.  
+{: deprecated}
+
+---
 
 When a new version of {{site.data.keyword.iotinsurance_short}} is available, a message is displayed in the {{site.data.keyword.iotinsurance_short}} service console. At that time, the **Setup** option becomes active, and you can upgrade quickly and easily.
 {:shortdesc}

--- a/iotinsurance_wally_integration.md
+++ b/iotinsurance_wally_integration.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2016, 2017
-lastupdated: "2017-12-11"
+lastupdated: "2017-12-28"
 ---
 
 <!-- Common attributes used in the template are defined as follows: -->
@@ -18,8 +18,14 @@ lastupdated: "2017-12-11"
 # Enabling support for Wally data (Deprecated)
 {: #wallysupport}
 
-**This service is deprecated:** Existing instances of this service can be used until 12 December 2018. For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.  
-{:deprecated}
+**This service is deprecated:** For more information, see the [deprecation announcement blog](https://www.ibm.com/blogs/bluemix/2017/11/iot-for-insurance-on-bluemix-migrated-to-saas-offering/){: new_window}.
+
+However, {{site.data.keyword.iotinsurance_short}} is not going away. As of 31 July 2017, {{site.data.keyword.iotinsurance_short}} became a SaaS offering. The SaaS offering is available on [IBM Marketplace](https://www.ibm.com/us-en/marketplace/ibm-iot-for-insurance){: new_window}. Product documentation for the {{site.data.keyword.iotinsurance_full}} SaaS offering is in the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSQNYQ/iot-insurance/kc_welcome.html){: new_window}.
+
+Existing instances of this service can be used until 12 December 2018. However, you are encouraged to migrate to the {{site.data.keyword.iotinsurance_short}} SaaS offering. If you have data from this service that you want to migrate to the SaaS offering, you must open a [ticket at https://console.bluemix.net/](https://console.bluemix.net/){: new_window} under **Support > Add Ticket**.  
+{: deprecated}
+
+---
 
 {{site.data.keyword.iotinsurance_full}} supports integration with data from Wally sensors and services. Wally is a third-party wireless sensor provider.
 {: shortdesc}


### PR DESCRIPTION
As these Bluemix topics are still coming up in Google searches, and
they have “(Deprecated)” in their titles, I do not want customers to
think that IoT4I has gone away completely if they don’t happen to read
the deprecation notice. VERY bad impression.
Added info about IoT4I SaaS on MarketPlace and its documentation (KC
Cloud) in every topic on production.